### PR TITLE
Add `README` translation for zh-CN

### DIFF
--- a/DOCUMENTATION_zh-CN.md
+++ b/DOCUMENTATION_zh-CN.md
@@ -1,0 +1,288 @@
+# MicroPython Tools Documentation
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+    - [Installation](#installation)
+    - [Setting Up a Run Configuration](#setting-up-a-run-configuration)
+- [Communication Types](#communication-types)
+    - [Serial](#serial)
+    - [WebREPL](#webrepl)
+    - [Multiple Simultaneous Connections](#multiple-simultaneous-connections)
+- [Stubs/Typehints](#stubstypehints)
+    - [Built-in stub package manager](#built-in-stub-package-manager)
+    - [Custom stub package](#custom-stub-package)
+- [File System Widget](#file-system-widget)
+    - [Drag and Drop](#drag-and-drop-in-file-system-widget)
+    - [Volume/SD card Support](#volume-support)
+- [REPL Widget](#repl-widget)
+- [Uploads](#uploads)
+    - [Run Configurations](#run-configurations)
+        - [Project](#project)
+        - [Selected MicroPython Sources Roots](#selected-micropython-sources-roots)
+        - [Custom Path](#custom-path)
+    - [Drag and Drop](#drag-and-drop-uploads)
+    - [Context Menu Actions](#context-menu-actions)
+- [Execute File in REPL](#execute-file-in-repl)
+    - [Run Configuration](#run-configuration)
+    - [Context menu Action](#context-menu-action)
+
+## Getting Started
+
+### Installation
+
+1. Ensure that you have the necessary drivers for communicating with your microcontroller installed.
+2. Ensure you have a JetBrains IDE version **2024.3 or newer** with the Python plugin installed.
+3. Go to the **Plugin Marketplace**, search for *MicroPython Tools*, and install the plugin.
+4. Open a project or create a new one.
+5. Go to `Settings → Languages & Frameworks → MicroPython Tools`.
+6. Enable **MicroPython support**.
+7. Select an appropriate **stub package**.
+8. Choose and configure your preferred **communication type**, then apply the settings.
+
+### Setting Up a Run Configuration
+
+To upload files to the device efficiently, you need to set up a run configuration:
+
+1. Go to the **Run Configurations** menu near the top right corner of your IDE.
+2. Create a new `MicroPython Tools → Upload` run configuration.
+3. Choose a run configuration type (*Project* is best for most use cases).
+4. Enable:
+    - "Reset on success"
+    - "Switch to REPL tab on success"
+    - "Synchronize"
+5. Configure paths to exclude from synchronization if needed (e.g. logs, OTA directories, persistent config files,
+   etc.).
+6. Create a new folder, right-click it, and mark it as a **MicroPython Sources Root**.
+
+You can now treat this folder as the file system root `/` of your device and structure your code accordingly.  
+When you make changes to your project, you can simply execute this run configuration — all new and modified items will
+be uploaded, and any items deleted from your project will also be deleted from the device.
+
+## Communication Types
+
+Both official ways (Serial, WebREPL) to communicate with MicroPython devices are supported. The plugin utilizes a highly
+optimized implementation of MicroPython's raw-paste mode with flow control. This ensures the fastest and most reliable
+communication that REPL can support.
+
+### Serial
+
+Serial communication is the best and most common way to work with MicroPython devices, it's the fastest and most
+reliable. It should be preferred over WebREPL whenever possible.
+
+By default, the plugin's port-select dropdown menu filters out serial ports without a detectable manufacturer entry -
+these ports often aren't hardware ports, but virtual ones (such as the default macOS "
+/dev/tty.Bluetooth-Incoming-Port").
+
+Some microcontrollers might not have the device manufacturer entry of their port populated and thus get filtered out
+when they shouldn't. If you can't find the port you want to connect to in the dropdown menu, but your computer does see
+it, try to disable this setting as it might be falsely filtering out this port.
+
+### WebREPL
+
+WebREPL is MicroPython's custom communication protocol meant to facilitate remote development on MicroPython devices. It
+was primarily intended for use by browsers, and for this reason it uses WebSockets instead of pure TCP connections
+(those are prohibited by browsers for security reasons).
+
+The protocol is unfinished, riddled with many bugs, highly-unoptimized and difficult to implement right in a tool such
+as this plugin due to being WebSocket based.
+
+The plugin's current WebREPL implementation is as fast as the protocol permits, however, despite that it's incredibly
+slow. Even simple scripts (such as File System scan) take long to execute, and uploads take ages.
+
+It's advisable to avoid WebREPL for any projects that involve uploads with sizes of hundreds of kilobytes and to explore
+custom remote development solutions if it is a necessity for your project.
+
+If you do want to use or try WebREPL even with all of its constraints, it's recommended to add a delay after
+starting a WebREPL server on the device to ensure that debug output isn't missed while the plugin is re-establishing a
+WebREPL connection after a device reset. Some more useful information can also be found in
+[this issue](https://github.com/lukaskremla/micropython-tools-jetbrains/issues/26#issuecomment-2843503240).
+
+### Multiple Simultaneous Connections
+
+At this time the plugin only supports a single active connection, supporting multiple simultaneous connections would be
+overly complex and ambiguous. Additionally, the plugin utilizes a modal (blocking) progress dialog while communicating
+with the device. This ensures files can't be modified during an upload and that no more than one action happens at once.
+
+Supporting more than one connected device at a time would require a complete rewrite and only offer diminishing returns
+due to the modal nature of the dialog.
+
+If you need to work with multiple devices simultaneously, you can either create a separate project for each device and
+then have them open simultaneously. Alternatively, you can combine this plugin with a command line tool such as mpremote
+or rshell and use the plugin for uploading code and the command line tool as a REPL monitor. More info can be found
+[here](https://github.com/lukaskremla/micropython-tools-jetbrains/discussions/24).
+
+## Stubs/Typehints
+
+MicroPython stubs make the IDE recognize MicroPython specific modules (machine, network) and the MicroPythons stdlib
+modules (asyncio, time). This brings auto-completion, code checking and allows you to see what methods are available.
+
+### Built-in stub package manager
+
+The plugin has a built-in MicroPython stub package manager. It utilizes MicroPython stubs by
+[Jos Verlinde](https://github.com/Josverl/micropython-stubs). The packages come bundled with the plugin, and you can
+select between them via the auto-completion text field.
+
+Just start typing "micropython" and you'll be able to browse the available packages.
+
+### Custom stub package
+
+You can also use your own custom stub packages like this:
+
+1. Disable the plugin's "Enable MicroPython stubs" option, so that it doesn't interfere with your customs stubs.
+2. Create a folder in your project, it can be called anything, `.stubs` for example.
+3. Mark the created folder as a `Sources Root` via the right click `Mark Directory as` action
+4. Put the `.pyi` files and directories containing them in the created folder. If your stubs also have an `stdlib`
+   folder, make sure to explicitly mark it as a `Sources Root` as well, otherwise it will be ignored.
+5. You may need to restart the IDE to trigger a typehint re-scan.
+
+## File System Widget
+
+The File System widget is one of the most useful features of this plugin. Being able to see the state of the file
+system and manage it just like on your computer’s OS is priceless.
+
+Due to the constrained nature of MicroPython, file system scans cannot occur in the background, they must interrupt code
+running on the device. In order for the file information that the plugin displays to be accurate, a scan is
+automatically carried out after every file system operation (uploads, deletions, creating directories, etc.)
+
+If this automatic refresh is cancelled, the plugin will disconnect, as it can no longer trust that the data it has
+reflects the true state of the device's file system.
+
+You can also trigger a refresh manually via the toolbar action, this is useful for when you want to see changes your
+code has made.
+
+### Drag and Drop in File System Widget
+
+The File System widget's tree items fully support drag and drop for both uploads and re-arranging the file system. More
+info on drag and drop uploads can be found [here](#drag-and-drop-uploads).
+
+### Volume Support
+
+The File System widget also supports mounted volumes (SD cards and more). This support works automatically for
+MicroPython versions 1.25+, which introduced an efficient way to query the device's mount points.
+
+The plugin will display SD cards and other mounted volumes on the top level similarly to the FS root "/". It will also
+display the stats of how much storage is used up, how much is available and some action descriptions will change to
+reflect that a volume is going to be affected.
+
+Volume support is also available for MicroPython versions below 1.25, it can be enabled by checking the "legacy volume
+support" checkbox in the settings.
+
+NOTE: Legacy support will slow down refresh operations anytime you connect a device with MicroPython version below 1.25,
+because the check is more comprehensive and demanding.
+
+## REPL Widget
+
+The REPL Widget of this plugin lets you directly access REPL as it is. This means that all MicroPython REPL keyboard
+shortcuts (Raw REPL, Paste mode, Reset) will get passed through to the device. For your comfort the plugin also exposes
+some commonly used REPL actions (reset and interrupt) into toolbar buttons.
+
+Enabling Auto Clear REPL will clear the terminal after every major action (FS refresh, upload, download, reset). This is
+useful to prevent cluttering of the terminal.
+
+## Uploads
+
+There are several options for uploading items. All of them will skip already uploaded files if the connected device is
+capable of calculating CRC32 hashes.
+
+### Run Configurations
+
+Run configurations are the main way to upload files to a MicroPython device. They allow you to upload and synchronize  
+the files on the target device with just a single click.
+
+There are three types of run configurations:
+
+1. Project
+2. Selected MicroPython Sources Roots
+3. Custom Path
+
+They differ in how files and folders to upload are selected. The other features (reset on success, switch to REPL tab,  
+and synchronize) behave the same across all of them.
+
+#### Project
+
+This is the run configuration that is going to be the best fit for most use cases. It can work in two ways, depending
+on  
+whether at least one MicroPython Sources Root is marked.
+
+##### No MicroPython Sources Roots Are Marked
+
+All files and folders in your project will be uploaded with target (on-device) paths relative to the project root. For  
+example:
+
+```MyProjectName/Folder1/SubFolder/Script.py``` will be uploaded as ```Folder1/SubFolder/Script.py```
+
+The algorithm will ignore and avoid uploading all items with a leading dot in their name, test source roots, and all  
+excluded folders and their children.
+
+##### One or More MicroPython Sources Roots Are Marked
+
+If one or more MicroPython Sources Roots are marked, then only children of the top-most MicroPython Sources Roots will
+be  
+uploaded to the device relative to them. The files will get uploaded like this:
+
+```MyProjectName/SomeFolder/MpySourcesRootMarkedFolder/Folder1/SubFolder/Script.py``` will be uploaded as  
+```Folder1/SubFolder/Script.py```
+
+Similarly to the project run configuration, all items with a leading dot in their name, test source roots, and all  
+excluded folders and their children will be skipped.
+
+#### Selected MicroPython Sources Roots
+
+This run configuration works similarly to the project run configuration when at least one MicroPython Sources Root is  
+selected. But instead of uploading all top-most MicroPython Sources Roots, you get to select which ones get uploaded.
+
+This is useful in scenarios where you have a folder with ```.py``` files and another with ```.mpy``` files. You can
+mark  
+each folder as a MicroPython Sources Root and then have two separate `Selected MPY sources roots` run  
+configurations — one for uploading ```.py``` files and another for uploading ```.mpy``` files.
+
+Test folders, leading dot items, and excluded folders are ignored the same way as the Project run configuration does it.
+
+#### Custom Path
+
+The last upload run configuration type is Custom Path. This allows you to select a specific folder or file and
+manually  
+configure where it gets uploaded. This can be useful for uploading `secrets.py` and similar files, or other cases  
+where the previous two types aren't appropriate for some reason.
+
+When a file is selected, it gets uploaded with the displayed target path. When a folder gets uploaded, its contents  
+will be uploaded to the `Upload to` path. So if you want to upload the whole folder and not just its contents, you  
+must specify it in the `Upload to` field.
+
+This run configuration type can also be useful if you want to upload a test source root, which would be ignored by the  
+previous two types. Excluded and leading dot items are still skipped.
+
+### Drag and Drop Uploads
+
+You can quickly upload items by dragging them from the project file tree to the File System tab in the plugin's tool  
+window. The items will get uploaded where they are dropped.
+
+Excluded and leading dot items are still skipped. Test source roots get uploaded if they are explicitly selected.
+
+### Context Menu Actions
+
+You can manually upload files by right-clicking them in the project file tree or in the editor tab of open files. They  
+can be uploaded directly to the device root `/`, relative to the project root, or relative to the parent-most  
+MicroPython Sources Root (if applicable).
+
+Excluded and leading dot items are still skipped. Test source roots get uploaded if they are explicitly selected.
+
+## Execute File in REPL
+
+Executing a file in REPL is a handy feature for a wide array of scenarios, from running test scripts, executing code
+fragments or wanting to avoid blocking a device off by a bug in your `main.py`. This plugin offers two ways to execute
+code directly in REPL without it ever touching the file system of your device.
+
+### Run Configuration
+
+Setting up an Execute File in REPL run configuration will allow you to easily run a file with one click or run a set of
+test files programmatically as a part of some larger run configuration chain. Only `.py` and `.mpy` are accepted.
+
+### Context menu Action
+
+The execute code in REPL action is available in multiple menus. It's available for `.py` and `.mpy` files when you
+right-click them in the project tree, and it's also available for files open in the editor, both in the file's editor
+tab and when right-clicking anywhere in the open editor.
+
+While you're in the file's editor you can also select code and execute just the selected Fragment in REPL.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,0 +1,90 @@
+# 适用于PyCharm, CLion, IntelliJ以及其他JetBrains系IDE的MicroPython工具
+
+[![JetBrains IntelliJ Downloads](https://img.shields.io/jetbrains/plugin/d/26227-micropython-tools?label=Downloads)](https://plugins.jetbrains.com/plugin/26227-micropython-tools)
+[![JetBrains IntelliJ Rating](https://img.shields.io/jetbrains/plugin/r/rating/26227-micropython-tools?label=Rating)](https://plugins.jetbrains.com/plugin/26227-micropython-tools)
+
+本项目是[JetBrains IntelliJ MicroPython plugin](https://github.com/JetBrains/intellij-micropython)的一个fork。
+感谢[Andrey Vlasovskikh](https://github.com/vlasovskikh)创建的原创插件以及
+[Ilia Motornyi](https://github.com/elmot) 关于通讯层和文件系统的原创工作。
+
+同时非常感谢 [Jos Verlinde](https://github.com/Josverl/micropython-stubs) 创建和维护本项目使用的MicroPython stubs。
+
+由于原本的Jetbrains插件开发缓慢，我已经决定fork它并且我想专注于支持
+更多我基于本人开发MicroPython的专业经验，认为是无价的特性。
+
+我相信MicroPython社区需要一个健壮的、维护频繁的以及开发好的工具，去把MicroPython
+
+的支持添加到现代工业化标准的IDE中。我的这个Fork就是为了解决这个愿景。
+
+本项目将会频繁的更新，我将频繁参与到开发新功能以及修复已存在的代码中的Bug。如果你在使用这个插件的时候遇到了问题，请开一个Issue。对于任何建议、意见或者是想要新功能，你可以随意的开始讨论。
+
+一些你可以期待马上就能实装的功能：
+
+- Stubs管理器的重置版，允许按需下载和更新Stubs。
+- 集成mpy-cross去编译机器码。
+
+长期计划：
+
+- 内置MicroPython固件刷写支持。
+- 在这个插件完全发布后，我可能会考虑开发针对于VSCode、或者Visual Studio 2022的MicroPython插件
+
+## 安装，开始和文档
+
+在[这里](https://github.com/lukaskremla/micropython-tools-jetbrains/blob/main/DOCUMENTATION_zh-CN.md)可以找到十分有用的提示和文档。
+
+## 主要功能
+
+### 文件系统组件
+
+- 十分简易的查看、交互设备文件系统上的文件。
+- 通过拖动来进行上传或者是重新组织文件系统。
+- 支持挂载其他存储介质（比如SD卡），并且显示存储占用。
+  ![File System Widget](media/file_system.png)
+
+### REPL组件
+
+- 与MicroPython的REPL交互
+- 所有的键盘快捷键都将会直接发送为设备（比如Raw REPL，复制模式等）
+  ![REPL Widget](media/repl.png)
+
+### 上传
+
+- 项目可以通过内容管理器、拖动或者运行配置来进行上传
+- 已经上传的文件会被自动跳过（使用CRC32）
+- 上传预览对话框展示了文件系统在上传文件之后将会变成什么样。
+  ![Upload Preview](media/upload_preview.png)
+
+### 运行配置
+
+- #### 上传
+    - 轻松的选择哪些文件要被上传
+    - 同步设备文件系统，使其仅包含上传的文件和文件夹
+    - 在同步时排除掉某个设备上的路径
+      ![Upload Run Configuration](media/run_configuration_upload.png)
+- #### 在REPL中运行
+    - 在不向设备上传任何内容的情况下于REPL中执行“.py”、“.mpy”文件或选定的代码片段。
+      ![Execute in REPL Run Configuration](media/run_configuration_execute.png)
+      ![Execute Code Fragment in REPL](media/execute_fragment.png)
+
+### MicroPython的Stubs
+
+- 内置Stubs管理集成所有可用的MicroPython Stubs包（作者： [Jos Verlinde](https://github.com/Josverl/micropython-stubs)）
+
+### 上下文菜单操作
+
+- 快速上传或者执行指定的文件
+  ![Context Menu File Actions](media/file_actions.png)
+- 自定义 "Mark as MicroPython Sources Root"操作，使得其允许与许多不同的JetBrains IDE兼容
+  ![Context Menu MicroPython Sources Actions](media/micropython_sources.png)
+
+### 设置
+
+![Settings](media/settings.png)
+
+## 要求
+
+* 一个有效的Python 3.10+ 的解释器
+* Python社区组件 (对于非PyCharm的IDE)
+* 一块安装了MicroPython固件的开发版 (版本1.20+)
+
+本插件基于Apache 2协议授权。


### PR DESCRIPTION
For documentations, I may wait for the 0.6.0 version update to translate it together (due to the large amount of text, issue #68 )